### PR TITLE
don't use strip-components=1 when extracting

### DIFF
--- a/dynamodb_setup.sh
+++ b/dynamodb_setup.sh
@@ -49,7 +49,7 @@ HERE=$(pwd)
 
 echo
 echo -n "Extracting archive: "
-tar xz --strip-components=1 -C ${DEPLOY_DIR} -f ${archive} 2>/dev/null
+tar xz -C ${DEPLOY_DIR} -f ${archive} 2>/dev/null
 if [ $? -gt 1 ]
 then
     (>&2 echo "extract failed")


### PR DESCRIPTION
the structure of the archive must have changed. when running I ended
up with libs and third party licenses in /opt/dynamodb and not the
actual DynamoDBLocal.jar.